### PR TITLE
Avoid release scan fixture home path

### DIFF
--- a/tests/test_mini_eq_instance.py
+++ b/tests/test_mini_eq_instance.py
@@ -10,7 +10,7 @@ from tests._mini_eq_imports import instance
 def test_detects_mini_eq_python_cmdline() -> None:
     assert instance.is_mini_eq_python_cmdline(("python3", "-m", "mini_eq", "--auto-route"))
     assert instance.is_mini_eq_python_cmdline(("/usr/bin/python3", "/tmp/repo/.venv/bin/mini-eq"))
-    assert not instance.is_mini_eq_python_cmdline(("python3", "/tmp/tool.py", "--repo-root", "/home/user/mini-eq"))
+    assert not instance.is_mini_eq_python_cmdline(("python3", "/tmp/tool.py", "--repo-root", "/tmp/other-project"))
     assert not instance.is_mini_eq_python_cmdline(("pytest", "tests/test_mini_eq_instance.py"))
     assert not instance.is_mini_eq_python_cmdline(("pipewire", "-c", "/tmp/mini-eq-a/filter-chain.conf"))
 


### PR DESCRIPTION
## Summary
- replace a test fixture home path with a neutral tmp path so release preflight leak scanning stays strict without flagging the fixture

## Validation
- .venv/bin/python -m pytest tests/test_mini_eq_instance.py tests/test_release_preflight.py -q
- git diff --check